### PR TITLE
some links in docs 404, updated links

### DIFF
--- a/ngl/api/index.html
+++ b/ngl/api/index.html
@@ -73,16 +73,16 @@
 				<p>NGL Viewer is a web application for molecular visualization. <a href="https://get.webgl.org/">WebGL</a> is employed to display molecules like proteins and DNA/RNA with a variety of representations.</p>
 				<p>See it in action:</p>
 				<ul>
-					<li><a href="https://arose.github.io/ngl/?script=showcase/ferredoxin">Web application</a></li>
+					<li><a href="https://nglviewer.org/ngl/?script=showcase/ferredoxin">Web application</a></li>
 					<li><a href="https://codepen.io/arose/full/oWOQMg/">X-ray viewer</a></li>
-					<li><a href="http://arose.github.io/ngl/gallery/index.html">Gallery</a></li>
+					<li><a href="https://nglviewer.org/ngl/gallery/index.html">Gallery</a></li>
 					<li><a href="https://codepen.io/pen?template=JNLMXb">CodePen template</a></li>
 					<li><a href="https://codepen.io/tag/ngl/">Pens tagged <em>ngl</em></a></li>
 				</ul>
 				<p>Documentation:</p>
 				<ul>
-					<li><a href="http://arose.github.io/ngl/api/identifiers.html">Reference</a></li>
-					<li><a href="http://arose.github.io/ngl/api/manual/index.html">Manual</a></li>
+					<li><a href="https://nglviewer.org/ngl/api/identifiers.html">Reference</a></li>
+					<li><a href="https://nglviewer.org/ngl/api/manual/index.html">Manual</a></li>
 				</ul>
 				<h2 id="features">Features</h2>
 				<ul>

--- a/ngldev/api/index.html
+++ b/ngldev/api/index.html
@@ -75,16 +75,16 @@
 				<p>NGL Viewer is a web application for molecular visualization. <a href="https://get.webgl.org/">WebGL</a> is employed to display molecules like proteins and DNA/RNA with a variety of representations.</p>
 				<p>See it in action:</p>
 				<ul>
-					<li><a href="https://arose.github.io/ngl/?script=showcase/ferredoxin">Web application</a></li>
+					<li><a href="https://nglviewer.org/ngl/?script=showcase/ferredoxin">Web application</a></li>
 					<li><a href="https://codepen.io/arose/full/oWOQMg/">X-ray viewer</a></li>
-					<li><a href="http://arose.github.io/ngl/gallery/index.html">Gallery</a></li>
+					<li><a href="https://nglviewer.org/ngl/gallery/index.html">Gallery</a></li>
 					<li><a href="https://codepen.io/pen?template=JNLMXb">CodePen template</a></li>
 					<li><a href="https://codepen.io/tag/ngl/">Pens tagged <em>ngl</em></a></li>
 				</ul>
 				<p>Documentation:</p>
 				<ul>
-					<li><a href="http://nglviewer.org/ngl/api/identifiers.html">Reference</a></li>
-					<li><a href="http://nglviewer.org/ngl/api/manual/index.html">Manual</a></li>
+					<li><a href="https://nglviewer.org/ngl/api/identifiers.html">Reference</a></li>
+					<li><a href="https://nglviewer.org/ngl/api/manual/index.html">Manual</a></li>
 				</ul>
 				<a href="#features" id="features" style="color: inherit; text-decoration: none;">
 					<h2>Features</h2>


### PR DESCRIPTION
When viewing the docs at [http://nglviewer.org/ngl/api/](http://nglviewer.org/ngl/api/) the links to the [Web Application](https://arose.github.io/ngl/?script=showcase/ferredoxin), [Gallery](http://arose.github.io/ngl/gallery/index.html), [Reference](http://arose.github.io/ngl/api/identifiers.html) and [Manual](http://arose.github.io/ngl/api/manual/index.html) currently give a 404 error. It looks to me like you have migrated from arose.github.io to nglviewer.org. 

I made these changes to fix the links.

Thanks for this awesome library.